### PR TITLE
Use === in generated code

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -169,7 +169,7 @@ function getNewLineDelimitedJSONDecodingStream<T>(): TransformStream<string, T> 
       }
       controller.buf += chunk
       while (controller.pos < controller.buf.length) {
-        if (controller.buf[controller.pos] == '\n') {
+        if (controller.buf[controller.pos] === '\n') {
           const line = controller.buf.substring(0, controller.pos)
           const response = JSON.parse(line)
           controller.enqueue(response.result)


### PR DESCRIPTION
Using === is recommended in modern JavaScript / TypeScript since it also
verifies for typing without any implicit conversions