### PR TITLE
remove optional field for ts_package to avoid protoc error

### DIFF
--- a/options/ts_package.proto
+++ b/options/ts_package.proto
@@ -7,5 +7,5 @@ option go_package = "github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts/option
 import "google/protobuf/descriptor.proto";
 
 extend google.protobuf.FileOptions {
-	  optional string ts_package = 50000;
+	  string ts_package = 50000;
 }


### PR DESCRIPTION
Errors

```
protoc-gen-grpc-gateway-ts/options/ts_package.proto:10:20: Explicit 'optional' labels are disallowed in the Proto3 syntax. To define 'optional' fields in Proto3, simply remove the 'optional' label, as fields are 'optional' by default.
google/protobuf/empty.proto:54:1: Import "protoc-gen-grpc-gateway-ts/options/ts_package.proto" was not found or had errors.
```