### PR TITLE
Add option enable_styling_check to toggle styling check, the option is false by default.

### DIFF
--- a/data/file.go
+++ b/data/file.go
@@ -26,6 +26,8 @@ type File struct {
 	TSFileName string
 	// PackageNonScalarType stores the type inside the same packages within the file, which will be used to figure out external dependencies inside the same package (different files)
 	PackageNonScalarType []Type
+	// EnableStylingCheck enables the styling check for the given file
+	EnableStylingCheck bool
 }
 
 // StableDependencies are dependencies in a stable order.

--- a/generator/template.go
+++ b/generator/template.go
@@ -66,6 +66,10 @@ export type {{.Name}} = {
 }
 {{end}}{{end}}
 
+{{- if not .EnableStylingCheck}}
+/* eslint-disable */
+// @ts-nocheck
+{{- end}}
 /*
 * This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
 */
@@ -86,6 +90,10 @@ type OneOf<T> =
 `
 
 const fetchTmpl = `
+{{- if not .EnableStylingCheck}}
+/* eslint-disable */
+// @ts-nocheck
+{{- end}}
 /*
 * This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
 */

--- a/integration_tests/scripts/gen-protos.sh
+++ b/integration_tests/scripts/gen-protos.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 USE_PROTO_NAMES=${1:-"false"}
+ENABLE_STYLING_CHECK=${2:-"false"}
 cd .. && go install && cd integration_tests && \
 	protoc -I .  -I ../.. \
-	--grpc-gateway-ts_out=logtostderr=true,use_proto_names=$USE_PROTO_NAMES,loglevel=debug:./ \
+	--grpc-gateway-ts_out=logtostderr=true,use_proto_names=$USE_PROTO_NAMES,enable_styling_check=$ENABLE_STYLING_CHECK,loglevel=debug:./ \
 	service.proto msg.proto empty.proto

--- a/integration_tests/scripts/source.sh
+++ b/integration_tests/scripts/source.sh
@@ -3,7 +3,7 @@
 function runTest {
   ORIG_NAME=${1:="false"}
   CONFIG_NAME=${2:="karma.conf.js"}
-  ./scripts/gen-protos.sh $ORIG_NAME
+  ./scripts/gen-protos.sh $ORIG_NAME true
   go run ./ -orig=$ORIG_NAME &
   pid=$!
 


### PR DESCRIPTION
This PR solves #16 

Making it an option to make sure the generated code disablees styling check by default, while leaving it on in the CI to make sure the generated code has some good level of readability.