### PR TITLE
Remove unused function from generated code

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -195,10 +195,6 @@ export function b64Decode(s: string): Uint8Array {
   return new Uint8Array(buffer);
 }
 
-function b64Test(s: string): boolean {
-	return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(s);
-}
-
 export interface InitReq extends RequestInit {
   pathPrefix?: string
 }


### PR DESCRIPTION
This commit removes a function in the generated code that is not used.

The generated `b64decode` is currently technically also unused, and causes unnecessary bloat of the generated code. I did not remove it, because it is currently used by the test to decode the bytes result from the response (as `bytes` are currently left untouched as it comes back from the gateway). Maybe it was left in as a convenience for users, but this plugin probably shouldn't act as a utility package for generic operations such as base64 decoding.

I think one of the following should happen:
- The plugin should also decode the base64 as it comes back from the gateway (to be consistent with the encoding when sending). In this case, it makes sense to keep the `b64decode` in, as it will be used by the generated code
- The `b64decode` function should be removed, and clients should choose to include their own base64 decoding if they need it. 

The former option breaks backwards compatibility, but is related to the open question on how to 
fix Issue 25 : should this plugin do transformations on the data or not? The path chosen for that issue impacts the right way to handle `bytes` data from the server as well.