### PR TITLE
Ensure to use / for import path

### DIFF
--- a/data/file.go
+++ b/data/file.go
@@ -106,7 +106,7 @@ func GetTSFileName(fileName string) string {
 	baseName := filepath.Base(fileName)
 	ext := filepath.Ext(fileName)
 	name := baseName[0 : len(baseName)-len(ext)]
-	return path.Join(filepath.Dir(fileName), name+".pb.ts")
+	return filepath.ToSlash(path.Join(filepath.Dir(fileName), name+".pb.ts"))
 }
 
 // Type is an interface to get type out of field and method arguments

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -117,7 +117,7 @@ func (t *TypeScriptGRPCGatewayGenerator) generateFile(fileData *data.File, tmpl 
 
 func (t *TypeScriptGRPCGatewayGenerator) generateFetchModule(tmpl *template.Template) (*plugin.CodeGeneratorResponse_File, error) {
 	w := bytes.NewBufferString("")
-	fileName := filepath.Join(t.Registry.FetchModuleDirectory, t.Registry.FetchModuleFilename)
+	fileName := filepath.ToSlash(filepath.Join(t.Registry.FetchModuleDirectory, t.Registry.FetchModuleFilename))
 	err := tmpl.Execute(w, &data.File{EnableStylingCheck: t.EnableStylingCheck})
 	if err != nil {
 		return nil, errors.Wrapf(err, "error generating fetch module at %s", fileName)

--- a/registry/file.go
+++ b/registry/file.go
@@ -79,7 +79,7 @@ func (r *Registry) addFetchModuleDependencies(fileData *data.File) error {
 	log.Debugf("added fetch dependency %s for %s", sourceFile, fileData.TSFileName)
 	fileData.Dependencies = append(fileData.Dependencies, &data.Dependency{
 		ModuleIdentifier: "fm",
-		SourceFile:       sourceFile,
+		SourceFile:       filepath.ToSlash(sourceFile),
 	})
 
 	return nil


### PR DESCRIPTION
Fixes import path with '\' is generated on Windows.