### PR TITLE
Throw non-JSON responses as errors

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -216,10 +216,15 @@ export function fetchReq<I, O>(path: string, init?: InitReq): Promise<O> {
 
   const url = pathPrefix ? ` + "`${pathPrefix}${path}`" + ` : path
 
-  return fetch(url, req).then(r => r.json().then((body: O) => {
-    if (!r.ok) { throw body; }
-    return body;
-  })) as Promise<O>
+  return fetch(url, req).then((r) =>
+    r
+      .json()
+      .catch((err) => { throw r; })
+      .then((body: O) => {
+        if (!r.ok) { throw body; }
+        return body;
+      }),
+   ) as Promise<O>;
 }
 
 // NotifyStreamEntityArrival is a callback that will be called on streaming entity arrival


### PR DESCRIPTION
I'm working to get the `{ redirect: 'manual' }` option working in my codebase, so that I can detect when a middleman is redirecting my requests to my API server and respond accordingly.

Currently, I'm finding that when I include this option and make a request that redirects, I get a `SyntaxError` thrown as a result. This is coming from `r.json()` since the browser returns a response object with `type: 'opaqueredirect'` which isn't a JSON string.

My proposed solution is to catch errors from the JSON conversion and throw the original response object as an error in that case, which works for my use case. I'm also open to other ways of making this original response object accessible to the caller, though.

I had trouble getting the integration tests to run, so that I could extend them and implement a test case for this. Trying to run `./scripts/gen-server-proto.sh` after making a change to the server to add an endpoint that redirects, I get:

```
--go_out: protoc-gen-go: plugins are not supported; use 'protoc --go-grpc_out=...' to generate gRPC

See https://grpc.io/docs/languages/go/quickstart/#regenerate-grpc-code for more information.
```