### PR TITLE
Handle well-known wrapper types in a way that matches grpc-gateway serialization/deserialization

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -546,7 +546,9 @@ func tsType(r *registry.Registry, fieldType data.Type) string {
 	}
 
 	typeStr := ""
-	if strings.Index(info.Type, ".") != 0 {
+	if mapWellKnownType(info.Type) != "" {
+		typeStr = mapWellKnownType(info.Type)
+	} else if strings.Index(info.Type, ".") != 0 {
 		typeStr = mapScalaType(info.Type)
 	} else if !info.IsExternal {
 		typeStr = typeInfo.PackageIdentifier
@@ -558,6 +560,24 @@ func tsType(r *registry.Registry, fieldType data.Type) string {
 		typeStr += "[]"
 	}
 	return typeStr
+}
+
+func mapWellKnownType(protoType string) string {
+	switch protoType {
+	case ".google.protobuf.BoolValue":
+		return "boolean | undefined"
+	case ".google.protobuf.StringValue":
+		return "string | undefined"
+	case ".google.protobuf.DoubleValue",
+		".google.protobuf.FloatValue",
+		".google.protobuf.Int32Value",
+		".google.protobuf.Int64Value",
+		".google.protobuf.UInt32Value",
+		".google.protobuf.UInt64Value":
+		return "number | undefined"
+	}
+
+	return ""
 }
 
 func mapScalaType(protoType string) string {

--- a/generator/template.go
+++ b/generator/template.go
@@ -356,15 +356,6 @@ function isPrimitive(value: unknown): boolean {
 }
 
 /**
- * Checks if given primitive is zero-value
- * @param  {Primitive} value
- * @return {boolean}
- */
-function isZeroValuePrimitive(value: Primitive): boolean {
-  return value === false || value === 0 || value === "";
-}
-
-/**
  * Flattens a deeply nested request payload and returns an object
  * with only primitive values and non-empty array of primitive values
  * as per https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
@@ -386,14 +377,11 @@ function flattenRequestPayload<T extends RequestPayload>(
         value.every(v => isPrimitive(v)) &&
         value.length > 0;
 
-      const isNonZeroValuePrimitive =
-        isPrimitive(value) && !isZeroValuePrimitive(value as Primitive);
-
       let objectToMerge = {};
 
       if (isPlainObject(value)) {
         objectToMerge = flattenRequestPayload(value as RequestPayload, newPath);
-      } else if (isNonZeroValuePrimitive || isNonEmptyPrimitiveArray) {
+      } else if (isPrimitive(value) || isNonEmptyPrimitiveArray) {
         objectToMerge = { [newPath]: value };
       }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -332,6 +332,11 @@ func (r *Registry) collectExternalDependenciesFromData(filesData map[string]*dat
 			if !ok {
 				return errors.Errorf("cannot find type info for %s, $v", typeName)
 			}
+			if typeInfo.File == "google/protobuf/wrappers.proto" {
+				// Skip well-known wrapper types without importing them as an external dependency,
+				// since their types are converted to native TypeScript types by mapWellKnownType.
+				continue
+			}
 			identifier := typeInfo.Package + "|" + typeInfo.File
 
 			if _, ok := dependencies[identifier]; !ok {


### PR DESCRIPTION
Given that the stated goal of this project is to generate idiomatic Typescript code for the grpc-gateway project, I thought this might be a useful contribution, but it seems like it's also a bit of a departure from existing behavior, so there might be some discussion.

Further work that I know is needed:
- A better way to check for or define these constant values we're checking for.
- Adding tests (I'm not able to get the tests to run).

------

The default JSON marshaller/unmarshaller for the grpc-gateway has the following behavior for well-known wrapper types like `BoolValue` and `StringValue`:
- Serializes those types as `boolean` or `string` types, or `undefined` if nil
- Expects incoming values for those types to be `boolean | undefined`, or `string | undefined`, and knows the difference between an empty param (empty value) and a missing param (nil value)

However, the default behavior of this library has a couple differences of behavior that make working with these wrapper types difficult/inconsistent/partially-broken:
1. Well-known wrapper types are serialized by importing an external file with that message definition, resulting in `{ value: boolean }` or `{ value: string }` as types
2. Well-known wrapper types can't be output to URL params by the helpers used in service client definitions, because zero-value query params are always omitted

This branch contains fixes for those two issues:
1. Well-known wrapper types are serialized as their Typescript-native equivalents, matching how grpc-gateway serializes them and expects them to be sent back.
2. URL param serialization is changed to allow serializing zero-values for primitive types (string, number, and boolean), which makes these well-known wrapper types work in GET request messages.